### PR TITLE
Resolve issue #12679

### DIFF
--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -10,8 +10,11 @@
     <div class="col-12">
       <div class="form-group">
         <label><b>Name for copied session*</b></label>
-        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
+        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" (ngModelChange)="onNameChange()" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
                required #newSessionName="ngModel">
+        <div *ngIf="errorMessage" class="text-danger">
+          {{ errorMessage }}
+        </div>
         <div [hidden]="newSessionName.valid || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             The field "Name for copied session" should not be empty.

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -25,12 +25,25 @@ export class CopySessionModalComponent {
   newFeedbackSessionName: string = '';
   copyToCourseSet: Set<string> = new Set<string>();
 
+  errorMessage: string = '';
+
   constructor(public activeModal: NgbActiveModal) {}
+
+  onNameChange(): void {
+    this.errorMessage = '';
+  }
 
   /**
    * Fires the copy event.
    */
   copy(): void {
+    if (this.newFeedbackSessionName.trim().length === 0) {
+      this.errorMessage = "The field \"Name for copied session\" should not be whitespace.";
+      return;
+    }
+
+    this.errorMessage = '';
+
     this.activeModal.close({
       newFeedbackSessionName: this.newFeedbackSessionName,
       sessionToCopyCourseId: this.sessionToCopyCourseId,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12679
Outline of Solution
My teammates and I analyzed and discussed the ts file for detecting the input of newfeedbacksessionname.
We found that the field was not checked for validity before the copy button was pressed.
We have now added a series of methods such as trim() to determine whether there are illegal spaces in the field.

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
